### PR TITLE
docs: update README banner image and alt/title text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-[![Banner](https://philipplentzen.dev/opengraph-image "kreativer entwickler. informatik student. aus der kaiserstadt.")](https://philipplentzen.dev/)
+[![Schriftzug mit einer Karte von Aachen und dem Text "kreativer entwickler. digitaler tüftler & öcher jong" in der Mitte, daneben die initialen PL für Philipp Lentzen](https://philipplentzen.dev/opengraph-image.jpg "kreativer entwickler. digitaler tüftler & öcher jong")](https://philipplentzen.dev/)


### PR DESCRIPTION
Update the README banner link to use the JPEG opengraph image
(opengraph-image.jpg) and revise the alt/title text to better describe
the visual: a lettering with a map of Aachen, the phrase "kreativer
entwickler. digitaler tüftler & öcher jong", and the initials PL for
Philipp Lentzen. This improves clarity and accessibility for users and
social previews by providing a more accurate description of the image.